### PR TITLE
fix: cannot read property 'some' of undefined

### DIFF
--- a/lib/print.js
+++ b/lib/print.js
@@ -106,7 +106,7 @@ exports.dictionaryapi = function(data, word) {
     return;
   }
   data.forEach(function(item) {
-    if (item.ew.some(function(w) { return w === word })) {
+    if (Array.isArray(item.ew) && item.ew.some(function(w) { return w === word })) {
       if (item.cx) {
         item.cx.forEach(function(cx_item) {
           log(chalk.gray(' - ') + chalk.green(cx_item.cl));


### PR DESCRIPTION
## What is the current behavior?

```shell
# eg: translate `person` or 'ready' get it.

TypeError: Cannot read property 'some' of undefined
    at /../fanyi/lib/print.js:109:17
```

## What is the new behavior?

judgment type to avoid error.