### PR TITLE
fix: fanyi config -S not working #71

### DIFF
--- a/bin/fanyi
+++ b/bin/fanyi
@@ -40,7 +40,8 @@ program
     if (process.argv.length === 3) {
       return runFY();
     }
-    const {color, iciba, youdao, dictionaryapi, say} = args
+    const {color, iciba, youdao, dictionaryapi} = args
+    const {say} = program.opts()
     const options = resolveOptions({ color, iciba, youdao, dictionaryapi, say });
     return config.write(options);
   });


### PR DESCRIPTION
In commander.js, if `option()` is already registered, the result of same `option()` can't be gotten from `command().option().action(args () => {})`. 
Here is official exmpale: https://github.com/tj/commander.js/blob/master/examples/positional-options.js