### PR TITLE
fix: ignore punycode module is deprecated warning in node 22

### DIFF
--- a/bin/fanyi.js
+++ b/bin/fanyi.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env node --no-deprecation
 
 const { Command } = require('commander');
 const chalk = require('chalk');


### PR DESCRIPTION
close https://github.com/afc163/fanyi/issues/114