### PR TITLE
在shebang中添加-S标志修复env无法传递参数问题

### DIFF
--- a/bin/fanyi.js
+++ b/bin/fanyi.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --no-deprecation
+#!/usr/bin/env -S node --no-deprecation
 
 const { Command } = require('commander');
 const chalk = require('chalk');


### PR DESCRIPTION
在shebang中添加-S标志修复env无法传递参数问题

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Add the `-S` flag to the shebang line in `fanyi.js` to fix the issue of `env` not passing arguments.

### Why are these changes being made?
The `-S` flag is necessary to ensure that the `env` command correctly interprets and passes the `--no-deprecation` argument to `node`, resolving a problem where arguments were not being passed as expected. This change ensures compatibility and proper execution of the script.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->