### PR TITLE
fix: iciba throw error when fy ant love

### DIFF
--- a/lib/print.js
+++ b/lib/print.js
@@ -24,7 +24,7 @@ exports.iciba = (data, options = {}) => {
   }
 
   // phonetic symbol
-  data.ps?.forEach((item, i) => {
+  data.ps?.forEach?.((item, i) => {
     firstLine += chalk.magenta(` ${i === 0 ? '英' : '美'}[ ${item} ] `);
   });
 
@@ -35,7 +35,7 @@ exports.iciba = (data, options = {}) => {
   }
 
   // pos & acceptation
-  data.pos?.forEach((item, i) => {
+  data.pos?.forEach?.((item, i) => {
     if (typeof data.pos[i] !== 'string' || !data.pos[i]) {
       return;
     }
@@ -48,7 +48,7 @@ exports.iciba = (data, options = {}) => {
     log();
   }
 
-  data.sent?.forEach((item, i) => {
+  data.sent?.forEach?.((item, i) => {
     if (typeof item.orig !== 'string' && item.orig[0]) {
       item.orig = item.orig[0].trim();
     }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -71,4 +71,9 @@ describe('fanyi CLI', () => {
     const { stdout } = await runScript(['list']);
     expect(stdout).toContain('fanyi history:');
   });
+
+  it('should not print error when translate "ant love"', async () => {
+    const { stderr } = await runScript(['ant love']);
+    expect(stderr).not.toContain('访问 iciba 失败');
+  });
 });


### PR DESCRIPTION
`fy ant love` 会报错。

<img width="344" alt="image" src="https://github.com/user-attachments/assets/295409bf-0b97-4184-ae57-a8253d18bb26">

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add optional chaining to prevent errors in the `iciba` function and include a test to ensure no errors occur when translating "ant love".

### Why are these changes being made?

The changes address an issue where the `iciba` function could throw errors if certain properties were undefined, by adding optional chaining to safely access these properties. The test ensures that the function handles specific input without errors, improving the robustness of the translation feature.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by 1ce5c4c4c7108915c2a04c938be879b2d257add0  | 
|--------|--------|

fix: prevent error in `iciba` with optional chaining for undefined data properties

### Summary:
Fixes error in `exports.iciba` by adding optional chaining to prevent errors with undefined data properties.

**Key points**:
- **Behavior**:
  - Fixes error in `exports.iciba` in `print.js` by adding optional chaining to `forEach` calls on `data.ps`, `data.pos`, and `data.sent`.
  - Ensures no error is thrown when translating "ant love".
- **Tests**:
  - Adds test case in `index.test.ts` to verify no error is printed when translating "ant love".


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->